### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are using [Graphite](https://github.com/graphite-project/graphite-web) & 
 ![Screenshot](https://raw.github.com/douban/graph-index/master/static/image/graph-index-server.png)
 ![Screenshot](https://raw.github.com/douban/graph-index/master/static/image/graph-index-plugin.png)
 
-#Running
+# Running
 
 First:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
